### PR TITLE
Optimize str0m writer

### DIFF
--- a/webrtc/str0m-server/src/main.rs
+++ b/webrtc/str0m-server/src/main.rs
@@ -41,15 +41,15 @@ impl PlatformConfig {
         #[cfg(windows)]
         {
             Self {
-                initial_batch_size: 5,
+                initial_batch_size: 3,
                 high_water_bytes: 2 * 1024 * 1024,  // 2 MiB
                 low_water_bytes: 1 * 1024 * 1024,   // 1 MiB
                 max_outputs_per_call: 10,
                 success_batches_for_growth: 10,
-                max_batch_size: 20,
+                max_batch_size: 10,
                 min_batch_size: 1,
                 check_backpressure_during_write: true,
-                check_backpressure_every_n_writes: 3,
+                check_backpressure_every_n_writes: 1,
             }
         }
         #[cfg(not(windows))]


### PR DESCRIPTION
- Use str0m backpressure helpers.
- More hacks.
- many Random optimizations
- was able to cut the time by 2x on linux, windows is still as slow (if you push more the socket will die anyway).
Now it matches pion and libwebrtc on linux (I think this is my I/O limit).

<img width="1709" height="862" alt="image" src="https://github.com/user-attachments/assets/b549df1f-f70e-4182-9dbf-74f46dc04e4f" />
